### PR TITLE
Fix race condition issue with critical regions by making entering blo…

### DIFF
--- a/src/REThreadingPrivate.cpp
+++ b/src/REThreadingPrivate.cpp
@@ -30,7 +30,7 @@ namespace FayeCpp {
 #if defined(__RE_THREADING_PTHREAD__)
 		if (_m) pthread_mutex_lock((pthread_mutex_t *)_m);
 #elif defined(__RE_THREADING_WINDOWS__)
-		if (_m) TryEnterCriticalSection((LPCRITICAL_SECTION)_m);
+		if (_m) EnterCriticalSection((LPCRITICAL_SECTION)_m);
 #endif
 	}
 


### PR DESCRIPTION
I encountered problems when the non-mutex owning thread tried to leave the critical region. In my understand this was caused by the "lock" call being non-blocking and no check being in place wether the locking was OK. This leads to a potential race condition and a thread trying to leave the region which another thread has currently locked. 
Made the "lock" call blocking therefore, which for me solved the issue. 
